### PR TITLE
fix sometimes create .ssh dir at wrong location

### DIFF
--- a/ssh-copy-id
+++ b/ssh-copy-id
@@ -38,7 +38,7 @@ if [ "$#" -lt 1 ] || [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
   exit 1
 fi
 
-{ eval "$GET_ID" ; } | ssh ${1%:} "umask 077; test -d .ssh || mkdir .ssh ; cat >> .ssh/authorized_keys" || exit 1
+{ eval "$GET_ID" ; } | ssh ${1%:} "umask 077; cd ~; test -d .ssh || mkdir .ssh ; cat >> .ssh/authorized_keys" || exit 1
 
 cat <<EOF
 Now try logging into the machine, with "ssh '${1%:}'", and check in:


### PR DESCRIPTION
if one used 'cd somedir ' in target server's .bashrc,  the ssh-copy-id will create .ssh dir at wrong place.
the commit fix this problem